### PR TITLE
Update logo

### DIFF
--- a/helm/rook-operator/Chart.yaml
+++ b/helm/rook-operator/Chart.yaml
@@ -5,7 +5,7 @@ dependencies:
     version: 0.2.0
 description: File, Block, and Object Storage Services for your Cloud-Native Environment
 engine: gotpl
-icon: https://s.giantswarm.io/app-icons/1/png/rook-operator-app-light.png
+icon: https://s.giantswarm.io/app-icons/2/svg/rook-dark.svg
 name: rook-operator
 sources:
   - https://github.com/rook/rook


### PR DESCRIPTION
Sets the logo for the rook app to [https://s.giantswarm.io/app-icons/2/svg/rook-dark.svg](https://s.giantswarm.io/app-icons/2/svg/rook-dark.svg)

![](https://s.giantswarm.io/app-icons/2/svg/rook-dark.svg)

Depends on https://github.com/giantswarm/web-assets/pull/62