### PR TITLE
Add cluster_type label to prometheus rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use prometheus rules only on MCs.
+- Add `cluster_type` label to prometheus rules.
 
 ## [2.1.0] - 2021-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use prometheus rules only on MCs.
+
 ## [2.1.0] - 2021-11-05
 
 ### Changed

--- a/helm/rook-operator/charts/monitoring/templates/ceph-cluster-rules.yaml
+++ b/helm/rook-operator/charts/monitoring/templates/ceph-cluster-rules.yaml
@@ -5,6 +5,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: {{ .Values.nameStub }}-ceph-cluster.rules
   namespace: {{ .Values.rules.deploymentNamespace }}
 spec:

--- a/helm/rook-operator/charts/monitoring/templates/ceph-mgr-rules.yaml
+++ b/helm/rook-operator/charts/monitoring/templates/ceph-mgr-rules.yaml
@@ -5,6 +5,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: {{ .Values.nameStub }}-ceph-mgr.rules
   namespace: {{ .Values.rules.deploymentNamespace }}
 spec:

--- a/helm/rook-operator/charts/monitoring/templates/ceph-mon-rules.yaml
+++ b/helm/rook-operator/charts/monitoring/templates/ceph-mon-rules.yaml
@@ -5,6 +5,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: {{ .Values.nameStub }}-ceph-mon.rules
   namespace: {{ .Values.rules.deploymentNamespace }}
 spec:

--- a/helm/rook-operator/charts/monitoring/templates/ceph-osd-rules.yaml
+++ b/helm/rook-operator/charts/monitoring/templates/ceph-osd-rules.yaml
@@ -5,6 +5,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: {{ .Values.nameStub }}-ceph-osd.rules
   namespace: {{ .Values.rules.deploymentNamespace }}
 spec:

--- a/helm/rook-operator/charts/monitoring/templates/ceph-pool-rules.yaml
+++ b/helm/rook-operator/charts/monitoring/templates/ceph-pool-rules.yaml
@@ -5,6 +5,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: {{ .Values.nameStub }}-ceph-pool.rules
   namespace: {{ .Values.rules.deploymentNamespace }}
 spec:


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-rocket will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->
Towards https://github.com/giantswarm/giantswarm/issues/19666

This PR:
- adds `cluster_type` label to ceph prometheus rules.

### Testing

Description on how {APP-NAME} can be tested.

- [ ] fresh install works
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] KVM

#### Other testing

Additional testing which should be carried out:

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid (more info on the values schema can be found [here](https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-updates/helm-values-schema/)).
