### PR TITLE
remove storage node toleration from operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove storage node toleration to ensure operator cannot be scheduled there ([#66](https://github.com/giantswarm/rook-operator-app/pull/66)).
+
 ## [2.1.0] - 2021-11-05
 
 ### Changed

--- a/helm/rook-operator/values.schema.json
+++ b/helm/rook-operator/values.schema.json
@@ -239,21 +239,7 @@
             }
         },
         "tolerations": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "effect": {
-                        "type": "string"
-                    },
-                    "key": {
-                        "type": "string"
-                    },
-                    "operator": {
-                        "type": "string"
-                    }
-                }
-            }
+            "type": "array"
         },
         "unreachableNodeTolerationSeconds": {
             "type": "integer"

--- a/helm/rook-operator/values.yaml
+++ b/helm/rook-operator/values.yaml
@@ -30,10 +30,7 @@ nodeSelector: {}
 #  disktype: ssd
 
 # Tolerations for the rook-ceph-operator to allow it to run on nodes with particular taints
-tolerations:
-- effect: NoSchedule
-  key: storage-node
-  operator: Exists
+tolerations: []
 
 # Delay to use in node.kubernetes.io/unreachable toleration
 unreachableNodeTolerationSeconds: 5


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-rocket will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- stops Rook operator being scheduled on storage nodes.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid (more info on the values schema can be found [here](https://intranet.giantswarm.io/docs/organizational-structure/teams/halo/app-updates/helm-values-schema/)).
