### PR TITLE
update library chart to upstream v1.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update the upstream helm chart to 1.8.8
+- Update the library helm chart to 1.8.8
 - Update the updating doc to accomodate the rook/rook repo restructuring.
 
 ## [2.4.0] - 2022-04-14

--- a/helm/rook-operator/charts/library/Chart.yaml
+++ b/helm/rook-operator/charts/library/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v2
+name: library
+description: A simple library chart to share content between Rook's charts
+version: 0.0.1
+type: library
+
+# Developer notes:
+# - all templates must start with an underscore, or Helm won't detect them
+# - library definitions should be named 'library.*'
+# - library definitions should avoid conditional logic unless necessary
+# - templates named with '_cluster-*' are for CephCluster-scoped resources
+# - cluster-scoped definitions are named 'library.cluster.*'
+# - prefer templates that are named to their purpose (prefer avoiding '_helper.tpl')
+# - prefer combining features that can be enabled/disabled together (e.g., monitoring or PSP) into
+#   feature templates rather than spreading the content among lower-level templates like
+#   '_*rolebinding.tpl'
+
+# Note on Rook's use of this chart as a chart dependency:
+# The library chart is a dependency of Rook's other charts; however, including the library chart in
+# the 'charts/' dir of dependent charts via a symlink does not require using
+# 'helm dependency update'. This is beneficial because Helm creates a tar file that changes each
+# time 'helm dependency update' is called, meaning we cannot use git to determine if someone failed
+# to update the chart upon submitting a pull request. A helm blog reports that symlinks work as
+# intended but are warned about because symlinked files could be sensitive, but we are just linking
+# our library and not anything outside of this repo.
+# https://helm.sh/blog/2019-10-30-helm-symlink-security-notice/

--- a/helm/rook-operator/charts/library/templates/_cluster-clusterrolebinding.tpl
+++ b/helm/rook-operator/charts/library/templates/_cluster-clusterrolebinding.tpl
@@ -1,0 +1,32 @@
+{{/*
+ClusterRoleBindings needed for running a Rook CephCluster
+*/}}
+{{- define "library.cluster.clusterrolebindings" }}
+# Allow the ceph mgr to access cluster-wide resources necessary for the mgr modules
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr-cluster{{ template "library.suffix-cluster-namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-mgr-cluster
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+# Allow the ceph osd to access cluster-wide resources necessary for determining their topology location
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-osd{{ template "library.suffix-cluster-namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-osd
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+{{- end }}

--- a/helm/rook-operator/charts/library/templates/_cluster-monitoring.tpl
+++ b/helm/rook-operator/charts/library/templates/_cluster-monitoring.tpl
@@ -1,0 +1,74 @@
+{{/*
+RBAC needed for enabling monitoring for a Rook CephCluster.
+These should be scoped to the namespace where the CephCluster is located.
+*/}}
+
+{{- define "library.cluster.monitoring.roles" -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitoring
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+rules:
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - servicemonitors
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+---
+# Allow management of monitoring resources in the mgr
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitoring-mgr
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - create
+  - update
+{{- end }}
+
+{{- define "library.cluster.monitoring.rolebindings" }}
+# Allow the operator to get ServiceMonitors in this cluster's namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitoring
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-system
+    namespace: {{ .Values.operatorNamespace | default .Release.Namespace }} # namespace:operator
+---
+# Allow creation of monitoring resources in the mgr
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitoring-mgr
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-monitoring-mgr
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-mgr
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+{{- end }}

--- a/helm/rook-operator/charts/library/templates/_cluster-psp.tpl
+++ b/helm/rook-operator/charts/library/templates/_cluster-psp.tpl
@@ -1,0 +1,64 @@
+{{/*
+RoleBindings needed to enable Pod Security Policies for a CephCluster.
+*/}}
+{{- define "library.cluster.psp.rolebindings" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-default-psp
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+  labels:
+    operator: rook
+    storage-backend: ceph
+    {{- include "library.rook-ceph.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-osd-psp
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-osd
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-mgr-psp
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-cmd-reporter-psp
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:rook
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-cmd-reporter
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+{{- end }}

--- a/helm/rook-operator/charts/library/templates/_cluster-role.tpl
+++ b/helm/rook-operator/charts/library/templates/_cluster-role.tpl
@@ -1,0 +1,113 @@
+{{/*
+Roles needed for running a Rook CephCluster
+*/}}
+{{- define "library.cluster.roles" }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-osd
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+rules:
+  # this is needed for rook's "key-management" CLI to fetch the vault token from the secret when
+  # validating the connection details
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: ["ceph.rook.io"]
+    resources: ["cephclusters", "cephclusters/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete"]
+---
+# Aspects of ceph-mgr that operate within the cluster's namespace
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ceph.rook.io
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/scale
+      - deployments
+    verbs:
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - delete
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+---
+# Aspects of ceph osd purge job that require access to the cluster namespace
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete" ]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "delete" ]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "update", "delete", "list"]
+{{- end }}

--- a/helm/rook-operator/charts/library/templates/_cluster-rolebinding.tpl
+++ b/helm/rook-operator/charts/library/templates/_cluster-rolebinding.tpl
@@ -1,0 +1,93 @@
+{{/*
+RoleBindings needed for running a Rook CephCluster
+*/}}
+{{- define "library.cluster.rolebindings" }}
+# Allow the operator to create resources in this cluster's namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-cluster-mgmt
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-cluster-mgmt
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-system
+    namespace: {{ .Values.operatorNamespace | default .Release.Namespace }} # namespace:operator
+---
+# Allow the osd pods in this namespace to work with configmaps
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-osd
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-osd
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+# Allow the ceph mgr to access resources scoped to the CephCluster namespace necessary for mgr modules
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-mgr
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+# Allow the ceph mgr to access resources in the Rook operator namespace necessary for mgr modules
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-mgr-system{{ template "library.suffix-cluster-namespace" . }}
+  namespace: {{ .Values.operatorNamespace | default .Release.Namespace }} # namespace:operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-mgr-system
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-mgr
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cmd-reporter
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-cmd-reporter
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+---
+# Allow the osd purge job to run in this namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-purge-osd
+subjects:
+  - kind: ServiceAccount
+    name: rook-ceph-purge-osd
+    namespace: {{ .Release.Namespace }} # namespace:cluster
+{{- end }}

--- a/helm/rook-operator/charts/library/templates/_cluster-serviceaccount.tpl
+++ b/helm/rook-operator/charts/library/templates/_cluster-serviceaccount.tpl
@@ -1,0 +1,48 @@
+{{/*
+ServiceAccounts needed for running a Rook CephCluster
+*/}}
+{{- define "library.cluster.serviceaccounts" }}
+# Service account for Ceph OSDs
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-osd
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+  labels:
+    operator: rook
+    storage-backend: ceph
+    {{- include "library.rook-ceph.labels" . | nindent 4 }}
+{{ include "library.imagePullSecrets" . }}
+---
+# Service account for Ceph mgrs
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-mgr
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+  labels:
+    operator: rook
+    storage-backend: ceph
+    {{- include "library.rook-ceph.labels" . | nindent 4 }}
+{{ include "library.imagePullSecrets" . }}
+---
+# Service account for the job that reports the Ceph version in an image
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cmd-reporter
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+  labels:
+    operator: rook
+    storage-backend: ceph
+    {{- include "library.rook-ceph.labels" . | nindent 4 }}
+{{ include "library.imagePullSecrets" . }}
+---
+# Service account for job that purges OSDs from a Rook-Ceph cluster
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-purge-osd
+  namespace: {{ .Release.Namespace }} # namespace:cluster
+{{ include "library.imagePullSecrets" . }}
+{{ end }}

--- a/helm/rook-operator/charts/library/templates/_imagepullsecret.tpl
+++ b/helm/rook-operator/charts/library/templates/_imagepullsecret.tpl
@@ -1,0 +1,13 @@
+{{/*
+Define imagePullSecrets option to pass to all service accounts
+*/}}
+{{- define "library.imagePullSecrets" }}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets }}
+{{- else }}
+  {{/* if the secrets are not included, include a comment for generating common.yaml */}}
+# imagePullSecrets:
+#   - name: my-registry-secret
+{{- end }}
+{{- end }}

--- a/helm/rook-operator/charts/library/templates/_recommended-labels.tpl
+++ b/helm/rook-operator/charts/library/templates/_recommended-labels.tpl
@@ -1,0 +1,9 @@
+{{/*
+Common labels
+*/}}
+{{- define "library.rook-ceph.labels" -}}
+app.kubernetes.io/part-of: rook-ceph-operator
+app.kubernetes.io/managed-by: helm
+app.kubernetes.io/created-by: helm
+helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- end }}

--- a/helm/rook-operator/charts/library/templates/_suffix-cluster-namespace.tpl
+++ b/helm/rook-operator/charts/library/templates/_suffix-cluster-namespace.tpl
@@ -1,0 +1,18 @@
+{{/*
+Some ClusterRoles or Roles in the operator namespace need to be bound to service accounts in the
+CephCluster namespace.
+If the cluster namespace is the same as the operator namespace, we want a binding with a basic name.
+  This is the case for the rook-ceph (Rook-Ceph Operator) chart.
+If the cluster namespace is different from the operator namespace, we want to name the binding
+  (in the operator namespace) with a suffixed that has the cluster namespace. This is the case for
+  some instances of the rook-ceph-cluster (CephCluster) chart
+*/}}
+
+{{- define "library.suffix-cluster-namespace" -}}
+{{/* the operator chart won't set .Values.operatorNamespace, so default to .Release.Namespace */}}
+{{- $operatorNamespace := .Values.operatorNamespace | default .Release.Namespace -}}
+{{- $clusterNamespace := .Release.Namespace -}}
+{{- if ne $clusterNamespace $operatorNamespace -}}
+{{ printf "-%s" $clusterNamespace }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-rocket will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

**EXTREMELY IMPORTANT: if you are updating the rook-operator helm chart from upstream via the git subtree method, you _must not_ squash merge this PR as it will break future updates. Standard merges only, please - you'll save future you a lot of pain.**


This PR:

- Squashed 'helm/rook-operator/charts/library/' content from commit abf6d8073
- updates changelog

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] I understand that I should not squash merge this PR if I am updating the `rook-operator` helm chart via the subtree method.
